### PR TITLE
[AP-141] Add repository standards artifacts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owners for everything in the repo
+* @Accompany-Health/orion
+
+# Documentation
+/docs/ @Accompany-Health/orion
+
+# GitHub Actions / CI
+/.github/ @Accompany-Health/orion @Accompany-Health/platform

--- a/context.yaml
+++ b/context.yaml
@@ -1,0 +1,47 @@
+name: "phonenumbers"
+type: library
+language:
+  - go
+owner:
+  team: "orion"
+  slack: "#eng-backend"
+  github: "@Accompany-Health/orion"
+tier: "tier2"
+lifecycle: production
+domain:
+  - shared
+  - utilities
+interfaces:
+  inbound: []
+  outbound: []
+runtime:
+  run_local: "N/A (library — no standalone process)"
+  test: "go test ./..."
+  build: "go build ./..."
+entrypoints:
+  - path: "phonenumbers.go"
+    purpose: "Core public API — Parse, Format, IsValidNumber, GetNumberType, etc."
+important_paths:
+  - path: "phonenumbers.go"
+    purpose: "Main library implementation (~2800 lines)"
+  - path: "gen/"
+    purpose: "Generated binary metadata blobs (territory formatting rules, carrier/geocoding/timezone maps)"
+  - path: "cmd/buildmetadata/"
+    purpose: "CLI tool to refresh metadata from upstream Google libphonenumber"
+  - path: "shortnumber_info.go"
+    purpose: "Short number (emergency/info service) validation"
+dependencies:
+  internal: []
+  infra: []
+  external:
+    - "nyaruka/phonenumbers (upstream Go fork this repo is based on — https://github.com/nyaruka/phonenumbers)"
+    - "google/libphonenumber (upstream metadata source — https://github.com/google/libphonenumber)"
+data_stores: []
+external_services: []
+docs:
+  readme: "./README.md"
+  architecture: "./docs/architecture.md"
+  local_dev: "./docs/local-development.md"
+  dependencies: "./docs/dependencies.md"
+  troubleshooting: "./docs/troubleshooting.md"
+  glossary: "./docs/glossary.md"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,103 @@
+# Architecture
+
+## Overview
+
+`phonenumbers` is a Go port of Google's [libphonenumber](https://github.com/google/libphonenumber) library. It is Accompany Health's fork of [nyaruka/phonenumbers](https://github.com/nyaruka/phonenumbers), maintained to stay current with upstream metadata and used across backend services for phone number parsing, formatting, and validation.
+
+The library has no network or database dependencies — it is a pure Go library that embeds all territory metadata at compile time.
+
+---
+
+## Package Structure
+
+```
+phonenumbers/
+├── phonenumbers.go          # Core public API (~2800 lines)
+├── phonenumbers_test.go     # Comprehensive test suite
+├── shortnumber_info.go      # Short number (emergency/info service) validation
+├── shortnumber_info_test.go
+├── matcher.go               # Phone number matching logic
+├── builder.go               # String/buffer building utilities
+├── insertablebuffer.go      # Custom byte buffer
+├── serialize.go             # Protobuf serialization/deserialization
+├── metadata_util.go         # Metadata helpers
+├── phonenumber.pb.go        # Generated protobuf — PhoneNumber message
+├── phonemetadata.pb.go      # Generated protobuf — PhoneMetadata message
+├── gen/                     # Embedded binary metadata blobs
+│   ├── metadata_bin.go              # Territory formatting/validation rules
+│   ├── shortnumber_metadata_bin.go  # Short number metadata
+│   ├── countrycode_to_region_bin.go # Country code → region mappings
+│   ├── prefix_to_carriers_bin.go    # Number prefix → carrier
+│   ├── prefix_to_geocodings_bin.go  # Number prefix → city/region (~1.1MB)
+│   └── prefix_to_timezone_bin.go    # Number prefix → timezone
+└── cmd/
+    ├── buildmetadata/       # CLI: regenerates gen/ from upstream XML
+    └── phoneparser/         # CLI: example phone number parser
+```
+
+---
+
+## Public API
+
+The root `phonenumbers` package exposes all public functions. Key functions:
+
+| Function | Description |
+|---|---|
+| `Parse(number, defaultRegion)` | Parse a phone number string into a `PhoneNumber` |
+| `Format(number, format)` | Format a `PhoneNumber` in E164/INTERNATIONAL/NATIONAL/RFC3966 |
+| `IsValidNumber(number)` | Check if a number is valid globally |
+| `IsValidNumberForRegion(number, region)` | Check validity for a specific region |
+| `IsPossibleNumber(number)` | Check if the format is possible (lighter than IsValid) |
+| `GetNumberType(number)` | Returns FIXED_LINE, MOBILE, TOLL_FREE, VOIP, etc. |
+| `GetRegionCodeForNumber(number)` | Determine the region from a parsed number |
+| `GetNationalSignificantNumber(number)` | Extract the national number portion |
+| `GetExampleNumber(regionCode)` | Return a valid example number for a region |
+| `NewShortNumberInfo()` | Returns a `ShortNumberInfo` for emergency/short number validation |
+
+### Phone Number Formats
+
+| Format | Example |
+|---|---|
+| `E164` | `+16502530000` |
+| `INTERNATIONAL` | `+1 650-253-0000` |
+| `NATIONAL` | `(650) 253-0000` |
+| `RFC3966` | `tel:+16502530000` |
+
+---
+
+## Data Architecture
+
+All territory metadata is embedded directly in Go source files under `gen/` as gzip-compressed, base64-encoded Protocol Buffer binary data. This means:
+
+- **No file I/O at runtime** — metadata is compiled into the binary
+- **Lazy loading with caching** — metadata for each territory is deserialized on first use and cached in memory
+- **~230 territories supported** — formatting rules, validation patterns, carrier/geocoding/timezone maps
+
+The `PhoneNumber` and `PhoneMetadata` types are defined as Protocol Buffer messages (`.proto` → `.pb.go`), providing efficient serialization.
+
+---
+
+## Metadata Update Flow
+
+When Google releases new libphonenumber metadata, the `buildmetadata` command regenerates all `gen/*.go` files:
+
+```
+go install github.com/Accompany-Health/phonenumbers/cmd/buildmetadata
+buildmetadata
+```
+
+Internally it:
+1. Clones/fetches the upstream Google libphonenumber repository
+2. Parses the XML metadata files
+3. Serializes to Protocol Buffers
+4. Gzip-compresses and base64-encodes the result
+5. Writes Go source files to `gen/`
+
+---
+
+## Design Principles
+
+1. **Strict port** — the aim is to match Google's libphonenumber behavior exactly. No custom features are added beyond what exists upstream.
+2. **Metadata fidelity** — always built against the latest upstream XML; the CHANGELOG records which libphonenumber metadata version each release targets.
+3. **Production-proven** — used daily at scale for parsing and validation across ~230 territories.
+4. **Zero infrastructure** — pure library with no runtime service dependencies.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,59 @@
+# Dependencies
+
+## Runtime Dependencies
+
+This is a pure Go library with **no runtime infrastructure dependencies** (no database, no network calls, no external services at runtime).
+
+---
+
+## Go Module Dependencies
+
+### Direct
+
+| Module | Version | Purpose |
+|---|---|---|
+| `github.com/stretchr/testify` | v1.9.0 | Test assertions |
+| `golang.org/x/exp` | v0.0.0-20240525044651 | Experimental utilities (slices, maps) |
+| `golang.org/x/text` | v0.15.0 | Unicode text normalization |
+| `google.golang.org/protobuf` | v1.34.1 | Protocol Buffer serialization for phone/metadata types |
+
+### Indirect
+
+| Module | Purpose |
+|---|---|
+| `github.com/davecgh/go-spew` | Testify dependency — deep value printing |
+| `github.com/pmezard/go-difflib` | Testify dependency — diff output |
+| `gopkg.in/yaml.v3` | Testify dependency — YAML marshaling |
+
+---
+
+## Upstream Dependencies
+
+This repo sits in a two-level fork chain:
+
+```
+google/libphonenumber  →  nyaruka/phonenumbers  →  Accompany-Health/phonenumbers
+      (Java, metadata)        (Go port)                  (this repo)
+```
+
+### nyaruka/phonenumbers — upstream Go codebase
+
+- **Source**: `https://github.com/nyaruka/phonenumbers`
+- **What we track**: Go implementation changes — bug fixes, new API additions, performance improvements, updated `.proto` definitions
+- **How to sync**: merge upstream commits from nyaruka into this repo (see [local-development.md](./local-development.md))
+
+### google/libphonenumber — upstream metadata source
+
+- **Source**: `https://github.com/google/libphonenumber`
+- **What we track**: Territory metadata XML files (formatting rules, valid number patterns, carrier/geo/timezone maps)
+- **Consumed by**: the `cmd/buildmetadata` CLI tool (run at development time, not runtime)
+- **Output**: gzip-compressed Protocol Buffer blobs embedded in `gen/*.go`
+- **How to sync**: run `buildmetadata` and commit the regenerated `gen/` files
+
+Both are **maintenance-time** dependencies only — neither is a runtime dependency.
+
+---
+
+## No Internal Dependencies
+
+This library does not depend on any other Accompany Health internal packages. It is a standalone utility library.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,44 @@
+# Glossary
+
+Terminology specific to the `phonenumbers` library.
+
+---
+
+**E.164**
+The international phone number format standardized by the ITU-T. Numbers are prefixed with `+` and the country calling code, with no spaces or punctuation (e.g., `+16502530000`). This is the canonical storage format.
+
+**INTERNATIONAL format**
+A human-readable format that includes the `+` country code and uses spaces or dashes as separators (e.g., `+1 650-253-0000`).
+
+**NATIONAL format**
+A country-specific human-readable format without the country code prefix, following local conventions (e.g., `(650) 253-0000` for US numbers).
+
+**RFC3966**
+A URI format for telephone numbers as defined in RFC 3966 (e.g., `tel:+16502530000`). Used in HTML `href` attributes and SIP contexts.
+
+**libphonenumber**
+Google's reference implementation of international phone number parsing and formatting, originally written in Java. This library is a Go port of it.
+
+**metadata**
+Territory-specific rules encoding valid number lengths, formatting patterns, national prefixes, carrier codes, and geographic area mappings. Sourced from Google's libphonenumber XML files and embedded in `gen/` as compiled binary blobs.
+
+**PhoneNumber**
+The Protocol Buffer message type representing a parsed phone number. Fields include `CountryCode` (integer), `NationalNumber` (uint64), `Extension` (string), and optional fields for Italian leading zero, raw input, and carrier/preferred domestic formats.
+
+**PhoneMetadata**
+The Protocol Buffer message type encoding all formatting and validation rules for a single territory (e.g., `US`, `GB`, `DE`).
+
+**ShortNumber**
+A short numeric code used for emergency services (e.g., `911`, `112`) or information services (e.g., `411`). Validated separately via `ShortNumberInfo`.
+
+**NNS (National Significant Number)**
+The portion of a phone number that is dialed after the country calling code and national prefix. Extracted via `GetNationalSignificantNumber`.
+
+**country calling code**
+The numeric prefix that identifies a country in the E.164 system (e.g., `1` for US/Canada, `44` for UK, `91` for India).
+
+**region code**
+A two-letter ISO 3166-1 alpha-2 code identifying a territory (e.g., `US`, `GB`, `IN`). Used as the `defaultRegion` parameter when parsing numbers that may lack a country code prefix.
+
+**number type**
+The classification of a phone number's use: `FIXED_LINE`, `MOBILE`, `FIXED_LINE_OR_MOBILE`, `TOLL_FREE`, `PREMIUM_RATE`, `SHARED_COST`, `VOIP`, `PERSONAL_NUMBER`, `PAGER`, `UAN`, `VOICEMAIL`, or `UNKNOWN`.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,105 @@
+# Local Development
+
+## Prerequisites
+
+- **Go 1.23+** — [Install Go](https://go.dev/doc/install)
+- **Git**
+- No database, Docker, or other infrastructure required — this is a pure Go library.
+
+---
+
+## Setup
+
+```bash
+git clone https://github.com/Accompany-Health/phonenumbers.git
+cd phonenumbers
+go mod download
+```
+
+---
+
+## Testing
+
+```bash
+# Run all tests
+go test ./...
+
+# Run with race detection (recommended before PRs)
+go test -race ./...
+
+# Run short tests only (skips slow tests)
+go test -short ./...
+
+# Run with coverage report
+go test ./... -coverprofile=coverage.out -covermode=atomic
+go tool cover -html=coverage.out
+```
+
+---
+
+## Linting
+
+```bash
+golangci-lint run
+```
+
+---
+
+## Building
+
+```bash
+go build ./...
+```
+
+---
+
+## Syncing with Upstream (nyaruka)
+
+This repo is a fork of [nyaruka/phonenumbers](https://github.com/nyaruka/phonenumbers). When nyaruka ships Go implementation changes (bug fixes, new APIs, `.proto` updates), pull them in:
+
+```bash
+# Add nyaruka as a remote (first time only)
+git remote add nyaruka https://github.com/nyaruka/phonenumbers.git
+
+# Fetch and merge upstream changes
+git fetch nyaruka
+git merge nyaruka/main
+```
+
+Resolve any conflicts, run `go test ./...`, and open a PR. Check nyaruka's CHANGELOG to summarize what changed.
+
+---
+
+## Updating Metadata
+
+When Google releases a new version of libphonenumber, regenerate the metadata blobs:
+
+```bash
+go install github.com/Accompany-Health/phonenumbers/cmd/buildmetadata
+$GOPATH/bin/buildmetadata
+```
+
+This clones the upstream repo, re-parses the XML, and overwrites the files in `gen/`. Commit the result and update `CHANGELOG.md` with the upstream metadata version.
+
+---
+
+## Using in Another Service
+
+```bash
+go get github.com/Accompany-Health/phonenumbers
+```
+
+```go
+import "github.com/Accompany-Health/phonenumbers"
+
+num, err := phonenumbers.Parse("6502530000", "US")
+formatted := phonenumbers.Format(num, phonenumbers.E164)  // "+16502530000"
+```
+
+---
+
+## Releasing
+
+1. Update `CHANGELOG.md` with the new version and what changed.
+2. Tag the release: `git tag v1.x.y && git push origin v1.x.y`
+3. The `.goreleaser.yml` config handles GitHub release creation via CI.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,61 @@
+# Troubleshooting
+
+## Unexpected Parsing or Formatting Results
+
+**Symptom**: `Parse` or `Format` returns a result that doesn't match expectations.
+
+**Steps**:
+1. Verify the result against the [libphonenumber online demo](https://libphonenumber.appspot.com). If the demo gives the same unexpected result, the issue is in Google's metadata or Java implementation — not this repo.
+2. If the demo gives the *correct* result, the bug is in the Go implementation. Check [nyaruka/phonenumbers issues](https://github.com/nyaruka/phonenumbers/issues) — as the upstream Go fork, they may have already fixed it or have an open issue.
+3. If nyaruka has a fix, pull it in via the upstream sync process (see [local-development.md](./local-development.md)).
+4. If the bug is not in nyaruka either, it may be a metadata issue — report to [google/libphonenumber](https://github.com/google/libphonenumber).
+5. If none of the above, open an issue on this repo with the input number, region, and expected/actual output.
+
+---
+
+## Metadata Appears Out of Date
+
+**Symptom**: A phone number that should be valid is rejected, or carrier/geo lookups return stale data.
+
+**Steps**:
+1. Check `CHANGELOG.md` for the metadata version this release was built against.
+2. Compare against the latest release tag in [google/libphonenumber](https://github.com/google/libphonenumber).
+3. If upstream has newer metadata, run the update:
+   ```bash
+   go install github.com/Accompany-Health/phonenumbers/cmd/buildmetadata
+   $GOPATH/bin/buildmetadata
+   ```
+4. Commit the regenerated `gen/` files and open a PR.
+
+---
+
+## Test Failures After a Metadata Update
+
+**Symptom**: Tests pass on `main` but fail after running `buildmetadata`.
+
+**Steps**:
+1. Diff the new `gen/` files against the previous ones to understand what changed.
+2. Check if [nyaruka/phonenumbers](https://github.com/nyaruka/phonenumbers) has a corresponding update — there may be test fixtures that need updating alongside the metadata.
+3. Run `go test -v ./...` to identify which specific test cases are failing and what the new vs. expected values are.
+
+---
+
+## Build Failures: Protobuf Errors
+
+**Symptom**: Compilation errors referencing `google.golang.org/protobuf` types.
+
+**Steps**:
+1. Ensure your local `google.golang.org/protobuf` version matches the one in `go.mod` (currently `v1.34.1`).
+2. Run `go mod tidy` to resolve any dependency drift.
+3. If using a local replace directive pointing to a different protobuf version, remove it.
+
+---
+
+## `golangci-lint` Failures
+
+**Symptom**: CI or local lint fails.
+
+**Steps**:
+1. Ensure your `golangci-lint` version matches what CI uses (check `.github/workflows/`).
+2. Run `golangci-lint run --fix` to auto-fix formatting issues.
+3. For new lint rules introduced in CI, check the lint config at the repo root.


### PR DESCRIPTION
## Jira
[AP-141](https://accompany.atlassian.net/browse/AP-141)

## Summary
The phonenumbers repo was at 12% compliance with Accompany Health's repository standards (only README.md present). This PR adds all 7 missing artifacts — context.yaml, CODEOWNERS, and a full docs/ directory — bringing the repo to 100% compliance. Content is tailored to reflect that this repo is a pure Go library with no runtime infrastructure dependencies, forked from nyaruka/phonenumbers (itself a port of Google's libphonenumber).

## Changes
- `context.yaml` — structured metadata for the audit dashboard and agents (type: library, owner: orion, fork chain documented in external dependencies)
- `CODEOWNERS` — `@Accompany-Health/orion` as default owner, `@Accompany-Health/platform` co-owner for `.github/`
- `docs/architecture.md` — package structure, public API surface, data architecture (embedded protobuf blobs), metadata update flow, design principles
- `docs/local-development.md` — setup, testing, linting, nyaruka upstream sync workflow, metadata regeneration, consuming in other services, releasing
- `docs/dependencies.md` — fork chain diagram (Google → nyaruka → AH), Go module deps, distinction between Go codebase upstream (nyaruka) and metadata upstream (Google)
- `docs/troubleshooting.md` — debugging path routes through nyaruka before Google; covers stale metadata, test failures after metadata update, protobuf/lint errors
- `docs/glossary.md` — E.164, phone number formats, PhoneNumber/PhoneMetadata types, ShortNumber, region codes, number types

## Verification
- [ ] Audit Dashboard at https://accompany-health.github.io/ah-agents/ shows phonenumbers at 100% compliance (from 12%)
- [ ] `context.yaml` is valid YAML and matches the repository standards schema
- [ ] `CODEOWNERS` correctly reflects `@Accompany-Health/orion` ownership
- [ ] All docs/ files render correctly on GitHub
- [ ] `go test ./...` passes (no inadvertent changes to Go source)

[AP-141]: https://accompany.atlassian.net/browse/AP-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ