### PR TITLE
[AP-43] Comprehensively update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,76 @@
-# ☎️ phonenumbers 
-[![Build Status](https://github.com/nyaruka/phonenumbers/workflows/CI/badge.svg)](https://github.com/nyaruka/phonenumbers/actions?query=workflow%3ACI) 
-[![codecov](https://codecov.io/gh/nyaruka/phonenumbers/branch/main/graph/badge.svg)](https://codecov.io/gh/nyaruka/phonenumbers)
-[![Go Reference](https://pkg.go.dev/badge/github.com/nyaruka/phonenumbers.svg)](https://pkg.go.dev/github.com/nyaruka/phonenumbers)
+# phonenumbers
 
-Go port of Google's [libphonenumber](https://github.com/google/libphonenumber), forked from [ttacon/libphonenumber](https://github.com/ttacon/libphonenumber). This library is used daily in production for parsing and validation of numbers worldwide and is well maintained. Please open an issue if you encounter any problems, and we'll do our best to address them.
+[![Build Status](https://github.com/Accompany-Health/phonenumbers/workflows/CI/badge.svg)](https://github.com/Accompany-Health/phonenumbers/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/Accompany-Health/phonenumbers/branch/main/graph/badge.svg)](https://codecov.io/gh/Accompany-Health/phonenumbers)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Accompany-Health/phonenumbers.svg)](https://pkg.go.dev/github.com/Accompany-Health/phonenumbers)
+
+## What this repo is
+
+Go port of Google's [libphonenumber](https://github.com/google/libphonenumber), forked from [nyaruka/phonenumbers](https://github.com/nyaruka/phonenumbers). Used across Accompany Health backend services to parse, format, and validate phone numbers for all world regions. This library supersedes the older `libphonenumber` repo.
+
+## What this owns
+
+- Phone number parsing from free-text and structured input
+- Formatting in E.164, INTERNATIONAL, NATIONAL, and RFC3966 formats
+- Validation (globally and per-region)
+- Number type detection (FIXED_LINE, MOBILE, TOLL_FREE, VOIP, etc.)
+- Short number lookup (emergency services, info lines)
+
+No runtime infrastructure — this is a pure Go library with no database, network, or service dependencies.
+
+## Related systems
+
+**Upstream (code):** [nyaruka/phonenumbers](https://github.com/nyaruka/phonenumbers) — the Go fork this repo tracks for implementation changes.
+
+**Upstream (metadata):** [google/libphonenumber](https://github.com/google/libphonenumber) — source of territory formatting/validation XML, refreshed via `cmd/buildmetadata`.
+
+**Downstream:** Any Accompany Health service that imports `github.com/Accompany-Health/phonenumbers`.
+
+## Stack
+
+- **Language:** Go 1.23
+- **Serialization:** Protocol Buffers (`google.golang.org/protobuf`)
+- **Metadata embedding:** Go `//go:embed` — gzipped XML/text files in `data/`
+
+## Local Development
+
+See [docs/local-development.md](docs/local-development.md) for setup, testing, linting, metadata refresh, and upstream sync instructions.
+
+## Environment variables
+
+None. This is a pure library with no runtime configuration.
+
+## Where key things live
+
+| Path | Purpose |
+|---|---|
+| `phonenumbers.go` | Public API — Parse, Format, IsValidNumber, GetNumberType, etc. |
+| `shortnumber_info.go` | Short number (emergency/info service) validation |
+| `data/` | Embedded gzipped metadata files (territory rules, carrier/geo/timezone maps) |
+| `metadata.go` | `go:embed` directives wiring `data/` into the binary |
+| `cmd/buildmetadata/` | CLI tool to refresh `data/` from upstream Google libphonenumber |
+
+## Deployment
+
+This is a versioned Go module. Consuming services import it via `go.mod`:
+
+```bash
+go get github.com/Accompany-Health/phonenumbers@v1.x.y
+```
+
+Releases are tag-triggered — pushing a `v1.x.y` tag runs `.goreleaser.yml` via CI and creates a GitHub release. Consuming services should pin a specific version tag.
+
+## Troubleshooting
+
+See [docs/troubleshooting.md](docs/troubleshooting.md) for common problems including unexpected parsing results, stale metadata, and build failures.
+
+## Ownership
+
+- **Team:** orion
+- **Slack:** #eng-backend
+- **CODEOWNERS:** `@Accompany-Health/orion`
+
+---
 
 > [!IMPORTANT]
 > The aim of this project is strictly to be a port and match as closely as possible the functionality in libphonenumber. Please don't submit feature requests for functionality that doesn't exist in libphonenumber.
@@ -11,35 +78,88 @@ Go port of Google's [libphonenumber](https://github.com/google/libphonenumber), 
 > [!IMPORTANT]
 > We use the metadata from libphonenumber so if you encounter unexpected parsing results, please first verify if the problem affects libphonenumber and report there if so. You can use their [online demo](https://libphonenumber.appspot.com) to quickly check parsing results.
 
+---
+
 ## Version Numbers
 
-As we don't want to bump our major semantic version number in step with the upstream library, we use independent version numbers than the Google libphonenumber repo. The release notes will mention what version of the metadata a release was built against.
+As we don't want to bump our major semantic version number in step with the upstream library, we use independent version numbers from the Google libphonenumber repo. Release notes will mention what version of the metadata a release was built against.
+
+---
 
 ## Usage
 
+### Installation
+
+```bash
+go get github.com/Accompany-Health/phonenumbers
+```
+
 ```go
-// parse our phone number
+import "github.com/Accompany-Health/phonenumbers"
+```
+
+The library is safe for concurrent use. Metadata is loaded lazily on first use and cached; there is no mutable shared state after initialization.
+
+### Parsing and formatting
+
+```go
+// Parse a phone number (region hint used when no country code is present)
 num, err := phonenumbers.Parse("6502530000", "US")
 
-// format it using national format
-formattedNum := phonenumbers.Format(num, phonenumbers.NATIONAL)
+// Format in various styles
+phonenumbers.Format(num, phonenumbers.E164)          // "+16502530000"
+phonenumbers.Format(num, phonenumbers.INTERNATIONAL) // "+1 650-253-0000"
+phonenumbers.Format(num, phonenumbers.NATIONAL)      // "(650) 253-0000"
+phonenumbers.Format(num, phonenumbers.RFC3966)       // "tel:+16502530000"
 ```
+
+### Validation
+
+```go
+phonenumbers.IsValidNumber(num)                    // true/false — globally valid
+phonenumbers.IsValidNumberForRegion(num, "US")     // true/false — valid for region
+phonenumbers.IsPossibleNumber(num)                 // true/false — plausible length
+```
+
+### Number type and region
+
+```go
+phonenumbers.GetNumberType(num)           // FIXED_LINE, MOBILE, TOLL_FREE, VOIP, ...
+phonenumbers.GetRegionCodeForNumber(num)  // "US", "GB", "IN", ...
+```
+
+### Short numbers (emergency / info services)
+
+```go
+sni := phonenumbers.NewShortNumberInfo()
+sni.IsEmergencyNumber("911", "US")        // true
+sni.IsValidShortNumberForRegion(num, "US")
+```
+
+---
 
 ## Updating Metadata
 
-The `buildmetadata` command will fetch the latest XML file from the official Google repo and rebuild the go source files 
-containing all the territory metadata, timezone and region maps.
-
-It will rebuild the following files:
-
- * `gen/metadata_bin.go` - protocol buffer definitions for all the various formats across countries etc..
- * `gen/shortnumber_metadata_bin.go` - protocol buffer definitions for ShortNumberMetadata.xml
- * `gen/countrycode_to_region_bin.go` - information needed to map a country code to a region
- * `gen/prefix_to_carrier_bin.go` - information needed to map a phone number prefix to a carrier
- * `gen/prefix_to_geocoding_bin.go` - information needed to map a phone number prefix to a city or region
- * `gen/prefix_to_timezone_bin.go` - information needed to map a phone number prefix to a city or region
+The `buildmetadata` command fetches the latest files from the official Google repo and rebuilds the gzipped metadata in `data/`:
 
 ```bash
-% go install github.com/Accompany-Health/phonenumbers/cmd/buildmetadata
-% $GOPATH/bin/buildmetadata
+go install github.com/Accompany-Health/phonenumbers/cmd/buildmetadata
+$GOPATH/bin/buildmetadata
 ```
+
+It will update the following files:
+
+- `data/metadata.xml.gz` — territory formatting and validation rules
+- `data/shortnumber_metadata.xml.gz` — short number metadata
+- `data/countrycode_to_region.xml.gz` — country code → region mappings
+- `data/prefix_to_timezone.xml.gz` — number prefix → timezone
+- `data/prefix_to_carriers/` — number prefix → carrier (per locale)
+- `data/prefix_to_geocodings/` — number prefix → city/region (per locale)
+
+Commit the updated files and note the upstream metadata version in `CHANGELOG.md`.
+
+---
+
+## Architecture
+
+See [docs/architecture.md](docs/architecture.md) for a detailed breakdown of package structure, the public API surface, and how metadata is embedded and loaded at runtime.


### PR DESCRIPTION
## Jira
[AP-43](https://accompany.atlassian.net/browse/AP-43)

## Summary
The existing README was the original upstream nyaruka README with minimal Accompany Health customisation and several stale references introduced by the recent main upgrade. This PR rewrites it to meet Accompany Health documentation standards and fully cover the library's API, integration patterns, and ownership.

## Changes
- **Badge URLs** — fixed CI, codecov, and Go Reference badges (were pointing to `nyaruka/phonenumbers`)
- **Updating Metadata section** — replaced removed `gen/*.go` file list with the current `data/*.gz` files (reflecting the `go:embed` approach introduced in the latest main)
- **Standards sections added** — What this repo is, What this owns, Related systems, Stack, Local Development (→ docs/), Environment variables, Where key things live, Deployment, Troubleshooting (→ docs/), Ownership
- **Usage expanded** — now covers `IsValidNumber`, `IsValidNumberForRegion`, `IsPossibleNumber`, `GetNumberType`, `GetRegionCodeForNumber`, `ShortNumberInfo`; includes `go get` installation snippet and thread-safety note
- **Architecture link** — bottom of README points to `docs/architecture.md` (created in AP-141)

## Verification
- [ ] README renders correctly on GitHub
- [ ] All badge links resolve to `Accompany-Health/phonenumbers`
- [ ] README comprehensively updated
- [ ] Architecture/design documented clearly (links to docs/architecture.md)
- [ ] Build process fully explained with all commands
- [ ] Test strategy and execution documented
- [ ] Local development setup guide complete (links to docs/local-development.md)
- [ ] All commands are copy-paste ready
- [ ] Common troubleshooting included (links to docs/troubleshooting.md)

[AP-43]: https://accompany.atlassian.net/browse/AP-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ